### PR TITLE
Use calculated cursorOffset rather than absolute position

### DIFF
--- a/macroTable.js
+++ b/macroTable.js
@@ -2668,9 +2668,8 @@
 
           //reposition the resizer, do it out of the thread for performance improvements
           setTimeout(function() {
-            self.$resizer.css('left', calculateReiszeColumnWidth(e.pageX, $columnToResize) + 'px');
+            self.$resizer.css('left', calculateReiszeColumnWidth(cursorOffset, $columnToResize) + 'px');
           }, 0);
-
 
         /* process reordering columns */
 


### PR DESCRIPTION
A bug exists where the column's resize handle is X pixels to the right of the cursor when the table is within an element with a margin-left of X pixels, because the absolute position of the cursor was used instead of the calculated offset.
